### PR TITLE
Make a couple of matching improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .DS_Store
 *~
 /node_modules
+
+# Vim swap files
+*.swp
+*.swo

--- a/src/meme.coffee
+++ b/src/meme.coffee
@@ -41,7 +41,7 @@ module.exports = (robot) ->
     memeGenerator msg, 'NryNmg', 'Y U NO', msg.match[1]
 
   robot.respond /aliens guy (.+)/i, (msg) ->
-    memeGenerator msg, 'sO-Hng', msg.match[1], ''
+    memeGenerator msg, 'sO-Hng', '', msg.match[1]
 
   robot.respond /iron price (.+)/i, (msg) ->
     memeGenerator msg, 'q06KuA', msg.match[1], 'Pay the iron price'
@@ -49,7 +49,7 @@ module.exports = (robot) ->
   robot.respond /brace yourself (.+)/i, (msg) ->
     memeGenerator msg, '_I74XA', 'Brace Yourself', msg.match[1]
 
-  robot.respond /(.*) (ALL the .*)/i, (msg) ->
+  robot.respond /(.+) (ALL the .+)/i, (msg) ->
     memeGenerator msg, 'Dv99KQ', msg.match[1], msg.match[2]
 
   robot.respond /(I DON'?T ALWAYS .*) (BUT WHEN I DO,? .*)/i, (msg) ->
@@ -88,7 +88,7 @@ module.exports = (robot) ->
   robot.respond /(IF .*), ((ARE|CAN|DO|DOES|HOW|IS|MAY|MIGHT|SHOULD|THEN|WHAT|WHEN|WHERE|WHICH|WHO|WHY|WILL|WON\'T|WOULD)[ \'N].*)/i, (msg) ->
     memeGenerator msg, '-kFVmQ', msg.match[1], msg.match[2] + (if msg.match[2].search(/\?$/)==(-1) then '?' else '')
 
-  robot.respond /(.*)(AND IT\'S GONE.*)/i, (msg) ->
+  robot.respond /(.*)(A+ND IT\'S GONE.*)/i, (msg) ->
     memeGenerator msg, 'uIZe3Q', msg.match[1], msg.match[2]
 
   robot.respond /WHAT IF I TOLD YOU (.*)/i, (msg) ->
@@ -103,10 +103,10 @@ module.exports = (robot) ->
   robot.respond /(IF .*)(THAT'D BE GREAT)/i, (msg) ->
     memeGenerator msg, 'q1cQXg', msg.match[1], msg.match[2]
 
-  robot.respond /(MUCH .*) ((SO|VERY) .*)/i, (msg) ->
+  robot.respond /((?:WOW )?(?:SUCH|MUCH) .*) ((SUCH|MUCH|SO|VERY|MANY) .*)/i, (msg) ->
     memeGenerator msg, 'AfO6hw', msg.match[1], msg.match[2]
 
-  robot.respond /(.*)(EVERYWHERE.*)/i, (msg) ->
+  robot.respond /(.+, .+)(EVERYWHERE.*)/i, (msg) ->
     memeGenerator msg, 'yDcY5w', msg.match[1], msg.match[2]
 
 ####


### PR DESCRIPTION
Alter the following match conditions:
- The caption on Aliens guy should be at the bottom
- Doge should respond to more statements. It should allow 'wow' at the
  start, optionally, and also like combinations of 'much', 'such',
  'so', 'very', etc.
- "x, x everywhere" shouldn't trigger unless it has a comma in it.
  Since it was using .\* as well, it would actually trigger for the
  string " everywhere", in fact.
- I've also fixed a .\* which ought really to be a .+ in "ALL THE
  THINGS", but tbh most of the .*s shouldn't accept empty strings so
  might be worth running over most of them and changing them
- "AAAAAND" it's gone should allow as many As as desired. Currently
  this was responding to "Blah aaaaaaaand it's gone" by generating a
  meme with "blah aaaaaaa" at the top and "and it's gone" at the
  bottom :P
- I also scratched my head in puzzlement over "WHAT THE FRIEND" but
  decided not to touch it.

Testing:

In the absence of a working test suite, I tested that I got the expected
results testing manually with the following phrases:
- aliens guy neolane
- wow much doge such fun
- such doge many still working
- successes, successes everywhere
- AMEND ALL THE THINGS
- Bug? Aaaaand it's gone
